### PR TITLE
[ADD] Elasticsearch support user define time format

### DIFF
--- a/elasticsearchwriter/doc/elasticsearchwriter.md
+++ b/elasticsearchwriter/doc/elasticsearchwriter.md
@@ -52,7 +52,7 @@
               { "name": "col_keyword", "type": "keyword" },
               { "name": "col_text", "type": "text", "analyzer": "ik_max_word"},
               { "name": "col_geo_point", "type": "geo_point" },
-              { "name": "col_date", "type": "date", "format": "yyyy-MM-dd HH:mm:ss"},
+              { "name": "col_date", "type": "date", "fromFormat": "yyyy-MM-dd HH:mm:ss"},
               { "name": "col_nested1", "type": "nested" },
               { "name": "col_nested2", "type": "nested" },
               { "name": "col_object1", "type": "object" },

--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESColumn.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/ESColumn.java
@@ -11,7 +11,9 @@ public class ESColumn {
 
     private String timezone;
 
-    private String format;
+    private String fromFormat;
+
+    private String toFormat;
 
     private Boolean array;
 
@@ -27,8 +29,8 @@ public class ESColumn {
         this.timezone = timezone;
     }
 
-    public void setFormat(String format) {
-        this.format = format;
+    public void setFromFormat(String fromFormat) {
+        this.fromFormat = fromFormat;
     }
 
     public String getName() {
@@ -43,8 +45,8 @@ public class ESColumn {
         return timezone;
     }
 
-    public String getFormat() {
-        return format;
+    public String getFromFormat() {
+        return fromFormat;
     }
 
     public void setTimezone(String timezone) {
@@ -61,5 +63,13 @@ public class ESColumn {
 
     public Boolean getArray() {
         return array;
+    }
+
+    public String getToFormat() {
+        return toFormat;
+    }
+
+    public void setToFormat(String toFormat) {
+        this.toFormat = toFormat;
     }
 }


### PR DESCRIPTION
Es writer time format only support standard time
with timezone. It's good to have unique time but
not good enough if user want Elasticsearch in
specific time format. This patch make different
time format in Elasticsearch come true