### PR TITLE
[FIX] ES-writer cleanup option keep index mapping

### DIFF
--- a/elasticsearchwriter/doc/elasticsearchwriter.md
+++ b/elasticsearchwriter/doc/elasticsearchwriter.md
@@ -39,6 +39,7 @@
             "index": "test-1",
             "type": "default",
             "cleanup": true,
+            "delete": false,
             "settings": {"index" :{"number_of_shards": 1, "number_of_replicas": 0}},
             "discovery": false,
             "batchSize": 1000,
@@ -96,7 +97,12 @@
  * 默认值：index名
 
 * cleanup
- * 描述：是否删除原表
+ * 描述：是否清空原表(保留 index mapping)
+ * 必选：否
+ * 默认值：false
+ 
+* delete
+ * 描述：是否删除原表(不保留 index mapping)
  * 必选：否
  * 默认值：false
 

--- a/elasticsearchwriter/pom.xml
+++ b/elasticsearchwriter/pom.xml
@@ -34,13 +34,8 @@
         </dependency>
         <dependency>
             <groupId>io.searchbox</groupId>
-            <artifactId>jest-common</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.searchbox</groupId>
             <artifactId>jest</artifactId>
-            <version>2.4.0</version>
+            <version>5.3.3</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/Key.java
+++ b/elasticsearchwriter/src/main/java/com/alibaba/datax/plugin/writer/elasticsearchwriter/Key.java
@@ -64,6 +64,10 @@ public final class Key {
         return conf.getBool("cleanup", false);
     }
 
+    public static boolean isDelete(Configuration conf) {
+        return conf.getBool("delete", false);
+    }
+
     public static boolean isDiscovery(Configuration conf) {
         return conf.getBool("discovery", false);
     }

--- a/elasticsearchwriter/src/main/resources/plugin_job_template.json
+++ b/elasticsearchwriter/src/main/resources/plugin_job_template.json
@@ -1,0 +1,15 @@
+{
+    "name": "elasticsearchwriter",
+    "parameter": {
+        "endpoint": "http://xxx:9200",
+        "accessId": "",
+        "accessKey": "",
+        "index": "",
+        "type": "",
+        "cleanup": true,
+        "discovery": false,
+        "batchSize": 1000,
+        "splitter": ",",
+        "column": []
+    }
+}


### PR DESCRIPTION
Current elasticsearchwriter clearUp option will delete
exists index and also delete index mapping, this will
break user's specific mapping. This patch use ES
delete-by-query to delete all document instead of delete
ES mapping

New behavior is:
* cleanup just delete all document
* delete will delete index just like before cleanup

Update Maven dependent due to delete-by-query only work
for after ES-5.X
ref: https://github.com/searchbox-io/Jest/pull/466

Fix: https://github.com/alibaba/DataX/issues/572