### PR TITLE
[TMP-Fix] HDFS reader error when ORC file to too big

### DIFF
--- a/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
+++ b/hdfsreader/src/main/java/com/alibaba/datax/plugin/reader/hdfsreader/DFSUtil.java
@@ -333,24 +333,29 @@ public class DFSUtil {
                 //TODO multy threads
                 InputSplit[] splits = in.getSplits(conf, 1);
 
-                RecordReader reader = in.getRecordReader(splits[0], conf, Reporter.NULL);
-                Object key = reader.createKey();
-                Object value = reader.createValue();
-                // 获取列信息
-                List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+                RecordReader reader = null;
+                for (InputSplit is: splits) {
+                    reader = in.getRecordReader(is, conf, Reporter.NULL);
+                    Object key = reader.createKey();
+                    Object value = reader.createValue();
+                    // 获取列信息
+                    List<? extends StructField> fields = inspector.getAllStructFieldRefs();
 
-                List<Object> recordFields;
-                while (reader.next(key, value)) {
-                    recordFields = new ArrayList<Object>();
+                    List<Object> recordFields;
+                    while (reader.next(key, value)) {
+                        recordFields = new ArrayList<Object>();
 
-                    for (int i = 0; i <= columnIndexMax; i++) {
-                        Object field = inspector.getStructFieldData(value, fields.get(i));
-                        recordFields.add(field);
+                        for (int i = 0; i <= columnIndexMax; i++) {
+                            Object field = inspector.getStructFieldData(value, fields.get(i));
+                            recordFields.add(field);
+                        }
+                        transportOneRecord(column, recordFields, recordSender,
+                                taskPluginCollector, isReadAllColumns, nullFormat);
                     }
-                    transportOneRecord(column, recordFields, recordSender,
-                            taskPluginCollector, isReadAllColumns, nullFormat);
                 }
-                reader.close();
+                if (reader != null) {
+                    reader.close();
+                }
             } catch (Exception e) {
                 String message = String.format("从orcfile文件路径[%s]中读取数据发生异常，请联系系统管理员。"
                         , sourceOrcFilePath);


### PR DESCRIPTION
When single ORC file is too big, `in.getSplits(conf, 1)`
return more than ONE InputSplit. so
`in.getRecordReader(splits[0], conf, Reporter.NULL)` just
read one of the split file, not the all, This patch temp
fix this bug using for loop, the better way is use multy
threads as TODO comment said