### PR TITLE
[Imp] Standard log file name

### DIFF
--- a/CHANGELOG-BETWEEN-UPSTREAM.md
+++ b/CHANGELOG-BETWEEN-UPSTREAM.md
@@ -10,6 +10,7 @@
 * 将 errorLimit 中的 percentage 统一成和日志提示进度中的 percentage 一致, 即 [0, 100] 的数字(去掉百分号)
 * Revert了增加`mergeable`的commit,因为他的行为和预想的不一样
 * 增加 HDFS reader 的 parquet 文件类型支持
+* 规范日志文件名的命名
 
 ---
 

--- a/core/src/main/bin/datax.py
+++ b/core/src/main/bin/datax.py
@@ -185,7 +185,8 @@ def buildStartCommand(options, args):
         if jobResource.lower().startswith("file://"):
             jobResource = jobResource[len("file://"):]
 
-    jobParams = ("-Dlog.file.name=%s") % (jobResource[-20:].replace('/', '_').replace('.', '_'))
+    job_file_name = os.path.basename(jobResource).rstrip('.json')
+    jobParams = ("-Dlog.file.name=%s") % job_file_name
     if options.params:
         jobParams = jobParams + " " + options.params
 

--- a/core/src/main/conf/logback.xml
+++ b/core/src/main/conf/logback.xml
@@ -3,7 +3,7 @@
     <property name="log.dir" value="${datax.home}/log/" />
     <property name="perf.dir" value="${datax.home}/log_perf/" />
     <timestamp key="ymd" datePattern="yyyy-MM-dd"/>
-    <timestamp key="byMillionSecond" datePattern="HH_mm_ss.SSS"/>
+    <timestamp key="byMillionSecond" datePattern="HHmmssSSS"/>
 
     <!-- 控制台输出 -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
This patch use standard log filename for Datax
Log filename use path and truncate only 20 letter
such as `_datax_job_test_json-20_38_54.361.log`
For now just use job filename and `HHmmssSSS`
such as `test-161053132.log`