### PR TITLE
[Bugfix] Use getCanonicalHostName instead of getHostName

### DIFF
--- a/common/src/main/java/com/alibaba/datax/common/util/HostUtils.java
+++ b/common/src/main/java/com/alibaba/datax/common/util/HostUtils.java
@@ -22,7 +22,7 @@ public class HostUtils {
         try {
             InetAddress addr = InetAddress.getLocalHost();
             ip = addr.getHostAddress();
-            hostname = addr.getHostName();
+            hostname = addr.getCanonicalHostName();
         } catch (UnknownHostException e) {
             log.error("Can't find out address: " + e.getMessage());
             ip = "UNKNOWN";


### PR DESCRIPTION
经测试还有查阅资料 getHostName() 有时候会有获取hostname错误的情况，
用 getCanonicalHostName() 可以避免这种情况

Co-authored-by: Dexter <947149689@qq.com>